### PR TITLE
Update URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,4 +232,4 @@ donovan.parks@gmail.com
 Robert Beiko
 beiko@cs.dal.ca
 
-Program website: http://kiwi.cs.dal.ca/Software/EBD
+Program website: http://kiwi.cs.dal.ca/Software/ExpressBetaDiversity


### PR DESCRIPTION
Thing is, is that URL still current? Version 1.0.7 is not documented there.