### PR TITLE
Fix compilation issue with C++11 and greater

### DIFF
--- a/source/NewickIO.cpp
+++ b/source/NewickIO.cpp
@@ -183,7 +183,7 @@ bool NewickIO::ParseNewickString(Tree<Node>& tree, const std::string& newickStr)
 void NewickIO::Write(Tree<Node>& tree, std::ostream& out) const
 {
 	// Checking the existence of specified file, and possibility to open it in write mode
-	assert(out != NULL);
+	assert(out);
 
 	out << "(";
 


### PR DESCRIPTION
Can no longer compare iostreams to NULL, but now you can check the value of a stream instead. Tiny issue, but fixes compilation for me on Ubuntu 17.10.